### PR TITLE
implémenter la page accueil avec les widgets TradingView

### DIFF
--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -1,5 +1,54 @@
+import {
+  MARKET_OVERVIEW_WIDGET_CONFIG,
+  HEATMAP_WIDGET_CONFIG,
+  MARKET_DATA_WIDGET_CONFIG,
+  TOP_STORIES_WIDGET_CONFIG,
+} from '@/lib/constants';
+import TradingViewWidget from '@/components/TradingViewWidget';
+
 const Home = () => {
-  return <div className='home-wrapper flex min-h-screen'>Accueil</div>;
+  const scriptUrl = `https://s3.tradingview.com/external-embedding/embed-widget-`;
+
+  return (
+    <div className='home-wrapper flex min-h-screen'>
+      <section className='home-section grid w-full gap-8'>
+        <div className='md:col-span-1 xl:col-span-1'>
+          <TradingViewWidget
+            title='Aperçu du marché'
+            scriptUrl={`${scriptUrl}market-overview.js`}
+            config={MARKET_OVERVIEW_WIDGET_CONFIG}
+            className='custom-chart'
+            height={600}
+          />
+        </div>
+        <div className='md-col-span xl:col-span-2'>
+          <TradingViewWidget
+            title='Carte thermique boursière'
+            scriptUrl={`${scriptUrl}stock-heatmap.js`}
+            config={HEATMAP_WIDGET_CONFIG}
+            height={600}
+          />
+        </div>
+      </section>
+      <section className='home-section grid w-full gap-8'>
+        <div className='h-full md:col-span-1 xl:col-span-1'>
+          <TradingViewWidget
+            title='Actualités du marché'
+            scriptUrl={`${scriptUrl}timeline.js`}
+            config={TOP_STORIES_WIDGET_CONFIG}
+            height={600}
+          />
+        </div>
+        <div className='h-full md:col-span-1 xl:col-span-2'>
+          <TradingViewWidget
+            scriptUrl={`${scriptUrl}market-quotes.js`}
+            config={MARKET_DATA_WIDGET_CONFIG}
+            height={600}
+          />
+        </div>
+      </section>
+    </div>
+  );
 };
 
 export default Home;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -10,7 +10,7 @@ const Header = () => {
         <Link href='/'>
           <Image
             src='/assets/icons/logo.svg'
-            alt='Signalist logo'
+            alt='Trendify logo'
             width={140}
             height={32}
             className='h-8 w-auto cursor-pointer'

--- a/components/TradingViewWidget.tsx
+++ b/components/TradingViewWidget.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import React, { memo } from 'react';
+import useTradingViewWidget from "@/hooks/useTradingViewWidget";
+import {cn} from "@/lib/utils";
+
+interface TradingViewWidgetProps {
+    title?: string;
+    scriptUrl: string;
+    config: Record<string, unknown>;
+    height?: number;
+    className?: string;
+}
+
+const TradingViewWidget = ({ title, scriptUrl, config, height = 600, className }: TradingViewWidgetProps) => {
+    const containerRef = useTradingViewWidget(scriptUrl, config, height);
+
+    return (
+        <div className="w-full">
+            {title && <h3 className="font-semibold text-2xl text-gray-100 mb-5">{title}</h3>}
+            <div className={cn('tradingview-widget-container', className)} ref={containerRef}>
+                <div className="tradingview-widget-container__widget" style={{ height, width: "100%" }} />
+            </div>
+        </div>
+    );
+}
+
+export default memo(TradingViewWidget);

--- a/hooks/useTradingViewWidget.tsx
+++ b/hooks/useTradingViewWidget.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect, useRef } from 'react';
+
+const useTradingViewWidget = (scriptUrl: string, config: Record<string, unknown>, height = 600) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    if (container.dataset.loaded) return;
+
+    container.innerHTML = `<div class="tradingview-widget-container__widget" style="width: 100%; height: ${height}px;"></div>`;
+
+    const script = document.createElement('script');
+    script.src = scriptUrl;
+    script.async = true;
+    script.innerHTML = JSON.stringify(config);
+
+    container.appendChild(script);
+    container.dataset.loaded = 'true';
+
+    return () => {
+      container.innerHTML = '';
+      delete container.dataset.loaded;
+    };
+  }, [scriptUrl, config, height]);
+
+  return containerRef;
+};
+
+export default useTradingViewWidget;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -3,3 +3,332 @@ export const NAV_ITEMS = [
   { href: '/search', label: 'Recherche' },
   { href: '/watchlist', label: 'Liste de suivi' },
 ];
+
+// Options du formulaire d'inscription
+export const INVESTMENT_GOALS = [
+  { value: 'Growth', label: 'Croissance' },
+  { value: 'Income', label: 'Revenus' },
+  { value: 'Balanced', label: 'Équilibré' },
+  { value: 'Conservative', label: 'Conservateur' },
+];
+
+export const RISK_TOLERANCE_OPTIONS = [
+  { value: 'Low', label: 'Faible' },
+  { value: 'Medium', label: 'Moyenne' },
+  { value: 'High', label: 'Élevée' },
+];
+
+export const PREFERRED_INDUSTRIES = [
+  { value: 'Technology', label: 'Technologie' },
+  { value: 'Healthcare', label: 'Santé' },
+  { value: 'Finance', label: 'Finance' },
+  { value: 'Energy', label: 'Énergie' },
+  { value: 'Consumer Goods', label: 'Biens de consommation' },
+];
+
+export const ALERT_TYPE_OPTIONS = [
+  { value: 'upper', label: 'Seuil supérieur' },
+  { value: 'lower', label: 'Seuil inférieur' },
+];
+
+export const CONDITION_OPTIONS = [
+  { value: 'greater', label: 'Supérieur à (>)' },
+  { value: 'less', label: 'Inférieur à (<)' },
+];
+
+// Graphiques TradingView
+export const MARKET_OVERVIEW_WIDGET_CONFIG = {
+  colorTheme: 'dark',
+  dateRange: '12M',
+  locale: 'fr',
+  largeChartUrl: '',
+  isTransparent: true,
+  showFloatingTooltip: true,
+  plotLineColorGrowing: '#0FEDBE',
+  plotLineColorFalling: '#0FEDBE',
+  gridLineColor: 'rgba(240, 243, 250, 0)',
+  scaleFontColor: '#DBDBDB',
+  belowLineFillColorGrowing: 'rgba(41, 98, 255, 0.12)',
+  belowLineFillColorFalling: 'rgba(41, 98, 255, 0.12)',
+  belowLineFillColorGrowingBottom: 'rgba(41, 98, 255, 0)',
+  belowLineFillColorFallingBottom: 'rgba(41, 98, 255, 0)',
+  symbolActiveColor: 'rgba(15, 237, 190, 0.05)',
+  tabs: [
+    {
+      title: 'Finance',
+      symbols: [
+        { s: 'NYSE:JPM', d: 'JPMorgan Chase' },
+        { s: 'NYSE:WFC', d: 'Wells Fargo' },
+        { s: 'NYSE:BAC', d: 'Bank of America' },
+        { s: 'NYSE:HSBC', d: 'HSBC Holdings' },
+        { s: 'NYSE:C', d: 'Citigroup' },
+        { s: 'NYSE:MA', d: 'Mastercard' },
+      ],
+    },
+    {
+      title: 'Technologie',
+      symbols: [
+        { s: 'NASDAQ:AAPL', d: 'Apple' },
+        { s: 'NASDAQ:GOOGL', d: 'Alphabet' },
+        { s: 'NASDAQ:MSFT', d: 'Microsoft' },
+        { s: 'NASDAQ:FB', d: 'Meta Platforms' },
+        { s: 'NYSE:ORCL', d: 'Oracle' },
+        { s: 'NASDAQ:INTC', d: 'Intel' },
+      ],
+    },
+    {
+      title: 'Services',
+      symbols: [
+        { s: 'NASDAQ:AMZN', d: 'Amazon' },
+        { s: 'NYSE:BABA', d: 'Alibaba Group' },
+        { s: 'NYSE:T', d: 'AT&T' },
+        { s: 'NYSE:WMT', d: 'Walmart' },
+        { s: 'NYSE:V', d: 'Visa' },
+      ],
+    },
+  ],
+  support_host: 'https://www.tradingview.com',
+  backgroundColor: '#141414',
+  width: '100%',
+  height: 600,
+  showSymbolLogo: true,
+  showChart: true,
+};
+
+export const HEATMAP_WIDGET_CONFIG = {
+  dataSource: 'SPX500',
+  blockSize: 'market_cap_basic',
+  blockColor: 'change',
+  grouping: 'sector',
+  isTransparent: true,
+  locale: 'fr',
+  symbolUrl: '',
+  colorTheme: 'dark',
+  exchanges: [],
+  hasTopBar: false,
+  isDataSetEnabled: false,
+  isZoomEnabled: true,
+  hasSymbolTooltip: true,
+  isMonoSize: false,
+  width: '100%',
+  height: '600',
+};
+
+export const TOP_STORIES_WIDGET_CONFIG = {
+  displayMode: 'regular',
+  feedMode: 'market',
+  colorTheme: 'dark',
+  isTransparent: true,
+  locale: 'fr',
+  market: 'stock',
+  width: '100%',
+  height: '600',
+};
+
+export const MARKET_DATA_WIDGET_CONFIG = {
+  title: 'Actions',
+  width: '100%',
+  height: 600,
+  locale: 'fr',
+  showSymbolLogo: true,
+  colorTheme: 'dark',
+  isTransparent: false,
+  backgroundColor: '#0F0F0F',
+  symbolsGroups: [
+    {
+      name: 'Finance',
+      symbols: [
+        { name: 'NYSE:JPM', displayName: 'JPMorgan Chase' },
+        { name: 'NYSE:WFC', displayName: 'Wells Fargo' },
+        { name: 'NYSE:BAC', displayName: 'Bank of America' },
+        { name: 'NYSE:HSBC', displayName: 'HSBC Holdings' },
+        { name: 'NYSE:C', displayName: 'Citigroup' },
+        { name: 'NYSE:MA', displayName: 'Mastercard' },
+      ],
+    },
+    {
+      name: 'Technologie',
+      symbols: [
+        { name: 'NASDAQ:AAPL', displayName: 'Apple' },
+        { name: 'NASDAQ:GOOGL', displayName: 'Alphabet' },
+        { name: 'NASDAQ:MSFT', displayName: 'Microsoft' },
+        { name: 'NASDAQ:FB', displayName: 'Meta Platforms' },
+        { name: 'NYSE:ORCL', displayName: 'Oracle' },
+        { name: 'NASDAQ:INTC', displayName: 'Intel' },
+      ],
+    },
+    {
+      name: 'Services',
+      symbols: [
+        { name: 'NASDAQ:AMZN', displayName: 'Amazon' },
+        { name: 'NYSE:BABA', displayName: 'Alibaba Group' },
+        { name: 'NYSE:T', displayName: 'AT&T' },
+        { name: 'NYSE:WMT', displayName: 'Walmart' },
+        { name: 'NYSE:V', displayName: 'Visa' },
+      ],
+    },
+  ],
+};
+
+export const SYMBOL_INFO_WIDGET_CONFIG = (symbol: string) => ({
+  symbol: symbol.toUpperCase(),
+  colorTheme: 'dark',
+  isTransparent: true,
+  locale: 'fr',
+  width: '100%',
+  height: 170,
+});
+
+export const CANDLE_CHART_WIDGET_CONFIG = (symbol: string) => ({
+  allow_symbol_change: false,
+  calendar: false,
+  details: true,
+  hide_side_toolbar: true,
+  hide_top_toolbar: false,
+  hide_legend: false,
+  hide_volume: false,
+  hotlist: false,
+  interval: 'D',
+  locale: 'fr',
+  save_image: false,
+  style: 1,
+  symbol: symbol.toUpperCase(),
+  theme: 'dark',
+  timezone: 'Etc/UTC',
+  backgroundColor: '#141414',
+  gridColor: '#141414',
+  watchlist: [],
+  withdateranges: false,
+  compareSymbols: [],
+  studies: [],
+  width: '100%',
+  height: 600,
+});
+
+export const BASELINE_WIDGET_CONFIG = (symbol: string) => ({
+  allow_symbol_change: false,
+  calendar: false,
+  details: false,
+  hide_side_toolbar: true,
+  hide_top_toolbar: false,
+  hide_legend: false,
+  hide_volume: false,
+  hotlist: false,
+  interval: 'D',
+  locale: 'fr',
+  save_image: false,
+  style: 10,
+  symbol: symbol.toUpperCase(),
+  theme: 'dark',
+  timezone: 'Etc/UTC',
+  backgroundColor: '#141414',
+  gridColor: '#141414',
+  watchlist: [],
+  withdateranges: false,
+  compareSymbols: [],
+  studies: [],
+  width: '100%',
+  height: 600,
+});
+
+export const TECHNICAL_ANALYSIS_WIDGET_CONFIG = (symbol: string) => ({
+  symbol: symbol.toUpperCase(),
+  colorTheme: 'dark',
+  isTransparent: 'true',
+  locale: 'fr',
+  width: '100%',
+  height: 400,
+  interval: '1h',
+  largeChartUrl: '',
+});
+
+export const COMPANY_PROFILE_WIDGET_CONFIG = (symbol: string) => ({
+  symbol: symbol.toUpperCase(),
+  colorTheme: 'dark',
+  isTransparent: 'true',
+  locale: 'fr',
+  width: '100%',
+  height: 440,
+});
+
+export const COMPANY_FINANCIALS_WIDGET_CONFIG = (symbol: string) => ({
+  symbol: symbol.toUpperCase(),
+  colorTheme: 'dark',
+  isTransparent: 'true',
+  locale: 'fr',
+  width: '100%',
+  height: 464,
+  displayMode: 'regular',
+  largeChartUrl: '',
+});
+
+export const POPULAR_STOCK_SYMBOLS = [
+  'AAPL',
+  'MSFT',
+  'GOOGL',
+  'AMZN',
+  'TSLA',
+  'META',
+  'NVDA',
+  'NFLX',
+  'ORCL',
+  'CRM',
+
+  'ADBE',
+  'INTC',
+  'AMD',
+  'PYPL',
+  'UBER',
+  'ZOOM',
+  'SPOT',
+  'SQ',
+  'SHOP',
+  'ROKU',
+
+  'SNOW',
+  'PLTR',
+  'COIN',
+  'RBLX',
+  'DDOG',
+  'CRWD',
+  'NET',
+  'OKTA',
+  'TWLO',
+  'ZM',
+
+  'DOCU',
+  'PTON',
+  'PINS',
+  'SNAP',
+  'LYFT',
+  'DASH',
+  'ABNB',
+  'RIVN',
+  'LCID',
+  'NIO',
+
+  'XPEV',
+  'LI',
+  'BABA',
+  'JD',
+  'PDD',
+  'TME',
+  'BILI',
+  'DIDI',
+  'GRAB',
+  'SE',
+];
+
+export const NO_MARKET_NEWS =
+  '<p class="mobile-text" style="margin:0 0 20px 0;font-size:16px;line-height:1.6;color:#4b5563;">Aucune actualité du marché disponible aujourd\'hui. Veuillez revenir demain.</p>';
+
+export const WATCHLIST_TABLE_HEADER = [
+  'Entreprise',
+  'Symbole',
+  'Prix',
+  'Variation',
+  'Capitalisation boursière',
+  'Ratio C/B',
+  'Alerte',
+  'Action',
+];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Replaced the static home view with an interactive market dashboard featuring multiple TradingView widgets (e.g., market overview, heatmap, top stories, market data) organized across two sections for richer insights.
  - Added support for configurable widget titles and heights to improve presentation and readability.

- Style
  - Updated header logo alt text to reflect new branding, improving clarity and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->